### PR TITLE
Switch ruleNames to use std::vector<std::wstring>.

### DIFF
--- a/org/antlr/v4/runtime/DefaultErrorStrategy.cpp
+++ b/org/antlr/v4/runtime/DefaultErrorStrategy.cpp
@@ -190,7 +190,7 @@ namespace org {
                 }
 
                 void DefaultErrorStrategy::reportFailedPredicate(Parser *recognizer, FailedPredicateException *e) {
-                    std::wstring ruleName = recognizer->getRuleNames()->at(recognizer->_ctx->getRuleIndex());
+                    std::wstring ruleName = recognizer->getRuleNames()[recognizer->_ctx->getRuleIndex()];
                     std::wstring msg = std::wstring(L"rule ") + ruleName + std::wstring(L" ") + e->getMessage();
                     recognizer->notifyErrorListeners(e->getOffendingToken(), msg, e);
                 }

--- a/org/antlr/v4/runtime/DiagnosticErrorListener.cpp
+++ b/org/antlr/v4/runtime/DiagnosticErrorListener.cpp
@@ -86,14 +86,12 @@ namespace org {
                     int decision = dfa->decision;
                     int ruleIndex = ((atn::ATNState*)dfa->atnStartState)->ruleIndex;
                     
-                    //JAVA TO C++ CONVERTER WARNING: Since the array size is not known in this declaration, Java to C++ Converter has converted this array to a pointer.  You will need to call 'delete[]' where appropriate:
-                    //ORIGINAL LINE: String[] ruleNames = recognizer.getRuleNames();
-                    std::vector<std::wstring> *ruleNames = recognizer->getRuleNames();
-                    if (ruleIndex < 0 || ruleIndex >= ruleNames->size()) {
+                    std::vector<std::wstring> ruleNames = recognizer->getRuleNames();
+                    if (ruleIndex < 0 || ruleIndex >= ruleNames.size()) {
                         return StringConverterHelper::toString(decision);
                     }
                     
-                    std::wstring ruleName = (*ruleNames)[ruleIndex];
+                    std::wstring ruleName = ruleNames[ruleIndex];
                     if (ruleName == L"" || ruleName.length() == 0)  {
                         return StringConverterHelper::toString(decision);
                     }

--- a/org/antlr/v4/runtime/Lexer.cpp
+++ b/org/antlr/v4/runtime/Lexer.cpp
@@ -272,12 +272,14 @@ namespace org {
                     return _channel;
                 }
 
-                std::wstring *Lexer::getModeNames() {
-                    return nullptr;
+                std::vector<std::wstring> Lexer::getModeNames() {
+                    std::vector<std::wstring> names;
+                    return names;
                 }
 
-                std::vector<std::wstring> *Lexer::getTokenNames() {
-                    return nullptr;
+                std::vector<std::wstring> Lexer::getTokenNames() {
+                    std::vector<std::wstring> names;
+                    return names;
                 }
 
                 std::vector<Token*> Lexer::getAllTokens() {

--- a/org/antlr/v4/runtime/Lexer.h
+++ b/org/antlr/v4/runtime/Lexer.h
@@ -220,14 +220,14 @@ namespace org {
 
                     virtual int getChannel();
 
-                    virtual std::wstring *getModeNames();
+                    virtual std::vector<std::wstring> getModeNames();
 
                     /// <summary>
                     /// Used to print out token names like ID during debugging and
                     ///  error reporting.  The generated parsers implement a method
                     ///  that overrides this to point to their String[] tokenNames.
                     /// </summary>
-                    virtual std::vector<std::wstring> *getTokenNames() override;
+                    virtual std::vector<std::wstring> getTokenNames() override;
 
                     /// <summary>
                     /// Return a list of all Token objects in input char stream.

--- a/org/antlr/v4/runtime/LexerInterpreter.cpp
+++ b/org/antlr/v4/runtime/LexerInterpreter.cpp
@@ -40,8 +40,7 @@ namespace org {
     namespace antlr {
         namespace v4 {
             namespace runtime {
-#ifdef TODO
-                LexerInterpreter::LexerInterpreter(const std::wstring &grammarFileName, std::vector<std::wstring> *tokenNames, std::vector<std::wstring> *ruleNames, std::vector<std::wstring> *modeNames, atn::ATN *atn, CharStream *input) : Lexer(_input), grammarFileName(grammarFileName), atn(atn), tokenNames(tokenNames/*->toArray(new std::wstring[tokenNames->size()]))*/, ruleNames(ruleNames/*->toArray(new std::wstring[ruleNames->size()])*/), modeNames(modeNames/*->toArray(new std::wstring[modeNames->size()])*/), _decisionToDFA(new std::vector<dfa::DFA*>()), _sharedContextCache(new atn::PredictionContextCache()) {
+                LexerInterpreter::LexerInterpreter(const std::wstring &grammarFileName, std::vector<std::wstring> *tokenNames, std::vector<std::wstring> *ruleNames, std::vector<std::wstring> *modeNames, atn::ATN *atn, CharStream *input) : Lexer(_input), grammarFileName(grammarFileName), atn(atn), _sharedContextCache(new atn::PredictionContextCache()) {
 
                     if (atn->grammarType != atn::ATNType::LEXER) {
                         throw new IllegalArgumentException(L"The ATN must be a lexer ATN.");
@@ -52,8 +51,16 @@ namespace org {
                         _decisionToDFA[i] = new dfa::DFA(atn->getDecisionState(i), i);
                     }
                     this->_interp = new atn::LexerATNSimulator(atn,_decisionToDFA,_sharedContextCache);
+                    if (tokenNames) {
+                        _tokenNames = *tokenNames;
+                    }
+                    if (ruleNames) {
+                        _ruleNames = *ruleNames;
+                    }
+                    if (modeNames) {
+                        _modeNames = *modeNames;
+                    }
                 }
-#endif
                 org::antlr::v4::runtime::atn::ATN *LexerInterpreter::getATN() {
                     return atn;
                 }
@@ -62,16 +69,16 @@ namespace org {
                     return grammarFileName;
                 }
 
-                std::vector<std::wstring> *LexerInterpreter::getTokenNames() {
-                    return tokenNames;
+                std::vector<std::wstring> LexerInterpreter::getTokenNames() {
+                    return _tokenNames;
                 }
 
-                std::vector<std::wstring> *LexerInterpreter::getRuleNames() {
-                    return ruleNames;
+                std::vector<std::wstring> LexerInterpreter::getRuleNames() {
+                    return _ruleNames;
                 }
 
-                std::wstring *LexerInterpreter::getModeNames() {
-                    return modeNames;
+                std::vector<std::wstring> LexerInterpreter::getModeNames() {
+                    return _modeNames;
                 }
             }
         }

--- a/org/antlr/v4/runtime/LexerInterpreter.h
+++ b/org/antlr/v4/runtime/LexerInterpreter.h
@@ -45,11 +45,11 @@ namespace org {
                     atn::ATN *const atn;
 
 
-                    std::vector<std::wstring> *tokenNames;
+                    std::vector<std::wstring> _tokenNames;
 
-                    std::vector<std::wstring> *ruleNames;
+                    std::vector<std::wstring> _ruleNames;
 
-                    std::wstring *modeNames;
+                    std::vector<std::wstring> _modeNames;
 
                     std::vector<dfa::DFA*> _decisionToDFA;
                     
@@ -62,11 +62,11 @@ namespace org {
 
                     virtual std::wstring getGrammarFileName() override;
 
-                    virtual std::vector<std::wstring> *getTokenNames() override;
+                    virtual std::vector<std::wstring> getTokenNames() override;
 
-                    virtual std::vector<std::wstring> *getRuleNames() override;
+                    virtual std::vector<std::wstring> getRuleNames() override;
 
-                    virtual std::wstring *getModeNames() override;
+                    virtual std::vector<std::wstring> getModeNames() override;
                 };
 
             }

--- a/org/antlr/v4/runtime/Parser.cpp
+++ b/org/antlr/v4/runtime/Parser.cpp
@@ -562,9 +562,7 @@ template<typename T1>
                 }
 
                 std::vector<std::wstring> Parser::getRuleInvocationStack(RuleContext *p) {
-//JAVA TO C++ CONVERTER WARNING: Since the array size is not known in this declaration, Java to C++ Converter has converted this array to a pointer.  You will need to call 'delete[]' where appropriate:
-//ORIGINAL LINE: String[] ruleNames = getRuleNames();
-                    std::wstring *ruleNames = getRuleNames();
+                    std::vector<std::wstring> ruleNames = getRuleNames();
                     std::vector<std::wstring> stack = std::vector<std::wstring>();
                     while (p != nullptr) {
                         // compute what follows who invoked us

--- a/org/antlr/v4/runtime/ParserInterpreter.cpp
+++ b/org/antlr/v4/runtime/ParserInterpreter.cpp
@@ -91,12 +91,12 @@ namespace org {
                     return atn;
                 }
 
-                std::vector<std::wstring> *ParserInterpreter::getTokenNames() {
-                    return tokenNames;
+                std::vector<std::wstring> ParserInterpreter::getTokenNames() {
+                    return _tokenNames;
                 }
 
-                std::vector<std::wstring> *ParserInterpreter::getRuleNames() {
-                    return ruleNames;
+                std::vector<std::wstring> ParserInterpreter::getRuleNames() {
+                    return _ruleNames;
                 }
 
                 std::wstring ParserInterpreter::getGrammarFileName() {

--- a/org/antlr/v4/runtime/ParserInterpreter.h
+++ b/org/antlr/v4/runtime/ParserInterpreter.h
@@ -67,8 +67,8 @@ namespace org {
                     atn::PredictionContextCache *const sharedContextCache;
 
 
-                    std::vector<std::wstring> *tokenNames;
-                    std::vector<std::wstring> *ruleNames;
+                    std::vector<std::wstring> _tokenNames;
+                    std::vector<std::wstring> _ruleNames;
 
                     std::deque<std::pair<ParserRuleContext*, int>*> *const _parentContextStack;
 
@@ -77,9 +77,9 @@ namespace org {
 
                     virtual atn::ATN *getATN() override;
 
-                    virtual std::vector<std::wstring> *getTokenNames() override;
+                    virtual std::vector<std::wstring> getTokenNames() override;
 
-                    virtual std::vector<std::wstring> *getRuleNames() override;
+                    virtual std::vector<std::wstring> getRuleNames() override;
 
                     virtual std::wstring getGrammarFileName() override;
 

--- a/org/antlr/v4/runtime/Recognizer.cpp
+++ b/org/antlr/v4/runtime/Recognizer.cpp
@@ -40,15 +40,6 @@ namespace org {
     namespace antlr {
         namespace v4 {
             namespace runtime {
-                
-                template<typename T1, typename T2>
-                std::map<std::wstring[] , std::map<std::wstring, int>*> *const
-                Recognizer<T1, T2>::tokenTypeMapCache = new std::map<std::wstring[] , std::map<std::wstring, int>*>();
-                
-                template<typename T1, typename T2>
-                std::map<std::wstring* , std::map<std::wstring, int>*> *const Recognizer<T1, T2>::ruleIndexMapCache = new std::map<std::wstring* , std::map<std::wstring, int>*>();
-                
-                
                template<typename T1, typename T2>
                 std::map<std::wstring, int> *Recognizer<T1, T2>::getTokenTypeMap() {
                     //JAVA TO C++ CONVERTER WARNING: Since the array size is not known in this declaration, Java to C++ Converter has converted this array to a pointer.  You will need to call 'delete[]' where appropriate:
@@ -75,21 +66,19 @@ namespace org {
 
                 template<typename T1, typename T2>
                 std::map<std::wstring, int> *Recognizer<T1, T2>::getRuleIndexMap() {
-                    //JAVA TO C++ CONVERTER WARNING: Since the array size is not known in this declaration, Java to C++ Converter has converted this array to a pointer.  You will need to call 'delete[]' where appropriate:
-                    //ORIGINAL LINE: String[] ruleNames = getRuleNames();
-                    std::wstring *ruleNames = getRuleNames();
-                    if (ruleNames == nullptr) {
+                    std::vector<std::wstring> ruleNames = getRuleNames();
+                    if (ruleNames.empty()) {
                         throw L"The current recognizer does not provide a list of rule names.";
                     }
 
                     //JAVA TO C++ CONVERTER TODO TASK: There is no built-in support for multithreading in native C++:
                     //synchronized(ruleIndexMapCache) {
-                    std::map<std::wstring, int> *result = ruleIndexMapCache->at(ruleNames);
+                    std::map<std::wstring, int> *result = _ruleIndexMapCache.at(ruleNames);
                     
                     if (result == nullptr) {
                         result = Utils::toMap(ruleNames);
 #ifdef TODO             // Why isn't this working??
-                        ruleIndexMapCache->insert(ruleNames, result);
+                        _ruleIndexMapCache->insert(ruleNames, result);
 #endif
                     }
 

--- a/org/antlr/v4/runtime/Recognizer.h
+++ b/org/antlr/v4/runtime/Recognizer.h
@@ -50,8 +50,8 @@ namespace org {
                     static const int _EOF = -1;
 
                 private:
-                    static std::map<std::wstring[] , std::map<std::wstring, int>*> *const tokenTypeMapCache;
-                    static std::map<std::wstring* , std::map<std::wstring, int>*> *const ruleIndexMapCache;
+                    static std::map<std::vector<std::wstring>, std::map<std::wstring, int>*> const _tokenTypeMapCache;
+                    static std::map<std::vector<std::wstring>, std::map<std::wstring, int>*> const _ruleIndexMapCache;
 
                     std::vector<ANTLRErrorListener*> _listeners;
 
@@ -73,9 +73,9 @@ namespace org {
                     ///  that overrides this to point to their String[] tokenNames.
                     /// </summary>
                 public:
-                    virtual std::vector<std::wstring> *getTokenNames() = 0;
+                    virtual std::vector<std::wstring> getTokenNames() = 0;
 
-                    virtual std::vector<std::wstring> *getRuleNames() = 0;
+                    virtual std::vector<std::wstring> getRuleNames() = 0;
 
                     /// <summary>
                     /// Get a map from token names to token types.

--- a/org/antlr/v4/runtime/RuleContext.cpp
+++ b/org/antlr/v4/runtime/RuleContext.cpp
@@ -129,24 +129,29 @@ namespace org {
 
 #ifdef TODO
                 Future<JDialog*> *RuleContext::inspect(Parser *parser) {
-                    std::vector<std::wstring> ruleNames = parser != nullptr ? Arrays::asList(parser->getRuleNames()) : nullptr;
-                    return inspect(ruleNames);
+                    return inspect(parser->getRuleNames());
                 }
 
 
-                Future<JDialog*> *RuleContext::inspect(std::vector<std::wstring> &ruleNames) {
+                Future<JDialog*> *RuleContext::inspect(const std::vector<std::wstring> &ruleNames) {
                     TreeViewer *viewer = new TreeViewer(ruleNames, this);
                     return viewer->open();
                 }
 #endif
                 void RuleContext::save(Parser *parser, const std::wstring &fileName) {
-                    std::vector<std::wstring>* ruleNames = parser != nullptr ? parser->getRuleNames() : nullptr;
-                    save(*ruleNames, fileName);
+                    std::vector<std::wstring> ruleNames;
+                    if (parser != nullptr) {
+                        ruleNames = parser->getRuleNames();
+                    }
+                    save(ruleNames, fileName);
                 }
 
                 void RuleContext::save(Parser *parser, const std::wstring &fileName, const std::wstring &fontName, int fontSize) {
-                    std::vector<std::wstring>* ruleNames = parser != nullptr ? parser->getRuleNames() : nullptr;
-                    save(*ruleNames, fileName, fontName, fontSize);
+                    std::vector<std::wstring> ruleNames;
+                    if (parser != nullptr) {
+                        ruleNames = parser->getRuleNames();
+                    }
+                    save(ruleNames, fileName, fontName, fontSize);
                 }
 
                 void RuleContext::save(std::vector<std::wstring> &ruleNames, const std::wstring &fileName) {
@@ -185,14 +190,7 @@ namespace org {
 
                 template<typename T1, typename T2>
                 std::wstring RuleContext::toString(Recognizer<T1, T2> *recog, RuleContext *stop) {
-//JAVA TO C++ CONVERTER WARNING: Since the array size is not known in this declaration, Java to C++ Converter has converted this array to a pointer.  You will need to call 'delete[]' where appropriate:
-//ORIGINAL LINE: String[] ruleNames = recog != nullptr ? recog.getRuleNames() : nullptr;
-                    std::wstring *ruleNames = recog != nullptr ? recog->getRuleNames() : nullptr;
-                    std::vector<std::wstring> ruleNamesList;
-                    if (ruleNames) {
-                        ruleNamesList.push_back(*ruleNames);
-                    }
-                    return toString(ruleNamesList, stop);
+                    return toString(recog->getRuleNames(), stop);
                 }
 
                 std::wstring RuleContext::toString(const std::vector<std::wstring> &ruleNames, RuleContext *stop) {

--- a/org/antlr/v4/runtime/atn/PredictionContextCache.h
+++ b/org/antlr/v4/runtime/atn/PredictionContextCache.h
@@ -35,6 +35,8 @@
  *  THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include "PredictionContext.h"
+
 namespace org {
 namespace antlr {
 namespace v4 {

--- a/org/antlr/v4/runtime/tree/Trees.cpp
+++ b/org/antlr/v4/runtime/tree/Trees.cpp
@@ -75,11 +75,7 @@ namespace org {
                     }
 
                     std::wstring Trees::toStringTree(Tree *t, Parser *recog) {
-//JAVA TO C++ CONVERTER WARNING: Since the array size is not known in this declaration, Java to C++ Converter has converted this array to a pointer.  You will need to call 'delete[]' where appropriate:
-//ORIGINAL LINE: String[] ruleNames = recog != nullptr ? recog.getRuleNames() : nullptr;
-                        std::wstring *ruleNames = recog != nullptr ? recog->getRuleNames() : nullptr;
-                        std::vector<std::wstring> ruleNamesList = ruleNames != nullptr ? Arrays::asList(ruleNames) : nullptr;
-                        return toStringTree(t, ruleNamesList);
+                        return toStringTree(t, recog->getRuleNames());
                     }
 
                     std::wstring Trees::toStringTree(Tree *t, std::vector<std::wstring> &ruleNames) {
@@ -103,9 +99,7 @@ namespace org {
                     }
                     
                     std::wstring Trees::getNodeText(Tree *t, Parser *recog) {
-                        std::wstring *ruleNames = recog != nullptr ? recog->getRuleNames() : nullptr;
-                        std::vector<std::wstring> ruleNamesList = ruleNames != nullptr ? Arrays::asList(ruleNames) : nullptr;
-                        return getNodeText(t, ruleNamesList);
+                        return getNodeText(t, recog->getRuleNames());
                     }
 
                     std::wstring Trees::getNodeText(Tree *t, std::vector<std::wstring> &ruleNames) {

--- a/org/antlr/v4/runtime/tree/xpath/XPathLexer.cpp
+++ b/org/antlr/v4/runtime/tree/xpath/XPathLexer.cpp
@@ -32,9 +32,9 @@
  */
 
 org::antlr::v4::runtime::atn::PredictionContextCache *const XPathLexer::_sharedContextCache = new org::antlr::v4::runtime::atn::PredictionContextCache();
-std::wstring XPathLexer::modeNames[1] = {L"DEFAULT_MODE"};
-const std::wstring XPathLexer::tokenNames[9] = {L"<INVALID>", L"TOKEN_REF", L"RULE_REF", L"'//'", L"'/'", L"'*'", L"'!'", L"ID", L"STRING"};
-const std::wstring XPathLexer::ruleNames[8] = {L"ANYWHERE", L"ROOT", L"WILDCARD", L"BANG", L"ID", L"NameChar", L"NameStartChar", L"STRING"};
+std::vector<std::wstring> XPathLexer::_modeNames = {L"DEFAULT_MODE"};
+const std::vector<std::wstring> XPathLexer::_tokenNames = {L"<INVALID>", L"TOKEN_REF", L"RULE_REF", L"'//'", L"'/'", L"'*'", L"'!'", L"ID", L"STRING"};
+const std::vector<std::wstring> XPathLexer::_ruleNames = {L"ANYWHERE", L"ROOT", L"WILDCARD", L"BANG", L"ID", L"NameChar", L"NameStartChar", L"STRING"};
 
 XPathLexer::XPathLexer(org::antlr::v4::runtime::CharStream *input) : org::antlr::v4::runtime::Lexer(input) {
 #ifdef TODO
@@ -46,19 +46,17 @@ std::wstring XPathLexer::getGrammarFileName() {
     return L"XPathLexer.g4";
 }
 
-#ifdef TODO
 // This will all be redone when generation is working
-std::vector<std::wstring>  * XPathLexer::getTokenNames() {
-    return tokenNames;
+std::vector<std::wstring> XPathLexer::getTokenNames() {
+    return _tokenNames;
 }
 
-std::vector<std::wstring> * XPathLexer::getRuleNames() {
-    return ruleNames;
+std::vector<std::wstring> XPathLexer::getRuleNames() {
+    return _ruleNames;
 }
-#endif
 
-std::wstring *XPathLexer::getModeNames() {
-    return modeNames;
+std::vector<std::wstring> XPathLexer::getModeNames() {
+    return _modeNames;
 }
 
 org::antlr::v4::runtime::atn::ATN *XPathLexer::getATN() {

--- a/org/antlr/v4/runtime/tree/xpath/XPathLexer.h
+++ b/org/antlr/v4/runtime/tree/xpath/XPathLexer.h
@@ -44,18 +44,18 @@ protected:
     static org::antlr::v4::runtime::atn::PredictionContextCache *const _sharedContextCache;
 public:
     static const int TOKEN_REF = 1, RULE_REF = 2, ANYWHERE = 3, ROOT = 4, WILDCARD = 5, BANG = 6, ID = 7, STRING = 8;
-    static std::wstring modeNames[1];
+    static std::vector<std::wstring> _modeNames;
 
-    static const std::wstring tokenNames[9];
-    static const std::wstring ruleNames[8];
+    static const std::vector<std::wstring> _tokenNames;
+    static const std::vector<std::wstring> _ruleNames;
 
 
     XPathLexer(org::antlr::v4::runtime::CharStream *input);
 
     virtual std::wstring getGrammarFileName() override;
-    virtual std::vector<std::wstring> *getTokenNames() override;
-    virtual std::vector<std::wstring> *getRuleNames() override;
-    virtual std::wstring *getModeNames() override;
+    virtual std::vector<std::wstring> getTokenNames() override;
+    virtual std::vector<std::wstring> getRuleNames() override;
+    virtual std::vector<std::wstring> getModeNames() override;
     virtual org::antlr::v4::runtime::atn::ATN *getATN() override;
     virtual void action(org::antlr::v4::runtime::RuleContext *_localctx, int ruleIndex, int actionIndex) override;
 private:


### PR DESCRIPTION
Changes the list of rule and token names to use a vector instead of an
array pointer.  This greatly simplifies memory management throughout
the code.  This particular design assumes we’ll be using C++11.  If
this is not the case, we can make the moves explicit (using std::move)
but that seems like a good thing to do if there is a future need to
support older/simpler compilers.