### PR TITLE
Change size() to return size_t

### DIFF
--- a/org/antlr/v4/runtime/ANTLRInputStream.cpp
+++ b/org/antlr/v4/runtime/ANTLRInputStream.cpp
@@ -155,7 +155,7 @@ namespace org {
                     return p;
                 }
 
-                int ANTLRInputStream::size() {
+                size_t ANTLRInputStream::size() {
                     return n;
                 }
 

--- a/org/antlr/v4/runtime/BufferedTokenStream.cpp
+++ b/org/antlr/v4/runtime/BufferedTokenStream.cpp
@@ -1,10 +1,10 @@
-﻿#include "BufferedTokenStream.h"
+﻿#include <assert.h>
+
+#include "BufferedTokenStream.h"
 #include "WritableToken.h"
 #include "Lexer.h"
 #include "Exceptions.h"
 #include "StringBuilder.h"
-
-#include <assert.h>
 
 /*
  * [The "BSD license"]

--- a/org/antlr/v4/runtime/CommonToken.cpp
+++ b/org/antlr/v4/runtime/CommonToken.cpp
@@ -102,7 +102,7 @@ namespace org {
                     if (input == nullptr) {
                         return L"";
                     }
-                    int n = input->size();
+                    size_t n = input->size();
                     if (start < n && stop < n) {
                         return input->getText(misc::Interval::of(start,stop));
                     } else {

--- a/org/antlr/v4/runtime/UnbufferedCharStream.cpp
+++ b/org/antlr/v4/runtime/UnbufferedCharStream.cpp
@@ -189,7 +189,7 @@ namespace org {
                     }
                 }
 
-                int UnbufferedCharStream::size() { 
+                size_t UnbufferedCharStream::size() {
                     throw UnsupportedOperationException(std::wstring(L"Unbuffered stream cannot know its size"));
                 }
 

--- a/org/antlr/v4/runtime/UnbufferedTokenStream.cpp
+++ b/org/antlr/v4/runtime/UnbufferedTokenStream.cpp
@@ -251,7 +251,7 @@ namespace org {
 				}
                 
 				template<typename T>
-                int UnbufferedTokenStream<T>::size()  {
+                size_t UnbufferedTokenStream<T>::size()  {
 					throw new UnsupportedOperationException(L"Unbuffered stream cannot know its size");
 				}
                 

--- a/org/antlr/v4/runtime/UnbufferedTokenStream.h
+++ b/org/antlr/v4/runtime/UnbufferedTokenStream.h
@@ -152,7 +152,7 @@ namespace org {
 
                     virtual void seek(int index) override;
 
-                    virtual int size() override;
+                    virtual size_t size() override;
 
                     virtual std::string getSourceName() override;
 

--- a/org/antlr/v4/runtime/atn/ATNConfigSet.cpp
+++ b/org/antlr/v4/runtime/atn/ATNConfigSet.cpp
@@ -1,4 +1,6 @@
-﻿#include "ATN.h"
+﻿#include <functional>
+
+#include "ATN.h"
 #include "ATNState.h"
 #include "ATNConfig.h"
 #include "Exceptions.h"
@@ -6,8 +8,6 @@
 #include "SemanticContext.h"
 #include "PredictionContext.h"
 #include "StringBuilder.h"
-
-#include <functional>
 
 /*
  * [The "BSD license"]

--- a/org/antlr/v4/runtime/atn/ATNDeserializer.cpp
+++ b/org/antlr/v4/runtime/atn/ATNDeserializer.cpp
@@ -98,7 +98,7 @@ namespace org {
                         return false;
                     }
 
-                    ATN *ATNDeserializer::deserialize(wchar_t data[]) {
+                    ATN *ATNDeserializer::deserialize(const std::wstring& data) {
                         // TODO: data = data->clone();
                         // don't adjust the first value since that's the version number
                         for (size_t i = 1; i < sizeof(data) / sizeof(data[0]); i++) {

--- a/org/antlr/v4/runtime/atn/ATNSerializer.cpp
+++ b/org/antlr/v4/runtime/atn/ATNSerializer.cpp
@@ -262,14 +262,16 @@ std::vector<int>* ATNSerializer::serialize() {
 
           break;
         case Transition::ACTION:
-          ActionTransition *at = static_cast<ActionTransition *>(t);
-          arg1 = at->ruleIndex;
-          arg2 = at->actionIndex;
-          if (arg2 == -1) {
-            arg2 = 0xFFFF;
-          }
+          {
+            ActionTransition *at = static_cast<ActionTransition *>(t);
+            arg1 = at->ruleIndex;
+            arg2 = at->actionIndex;
+            if (arg2 == -1) {
+              arg2 = 0xFFFF;
+            }
 
-          arg3 = at->isCtxDependent ? 1 : 0;
+            arg3 = at->isCtxDependent ? 1 : 0;
+          }
           break;
         case Transition::SET:
           arg1 = (*setIndices)[(static_cast<SetTransition *>(t))->set];


### PR DESCRIPTION
There are a lot of uses of size() that quickly start using integer math
(losing precision) but size() is okay in C++ as long as we’re willing
to use exceptions.  If we’re not, we can revisit after we get
everything compiling.

We should start converting the failed conversions into int with some
comment (or util function) so we can easily find and revert all of
these cases if/when we change our mind.