### PR TITLE
Switch from *wchar_t to std::wstring_t

### DIFF
--- a/org/antlr/v4/runtime/UnbufferedCharStream.cpp
+++ b/org/antlr/v4/runtime/UnbufferedCharStream.cpp
@@ -106,8 +106,8 @@ namespace org {
                 }
 
                 void UnbufferedCharStream::add(int c) {
-                    if (n >= data->length) {
-                        data = Arrays::copyOf(data, data->length * 2);
+                    if (n >= data.size()) {
+                        data.reserve(data.size()*2);
                     }
                     data[n++] = static_cast<wchar_t>(c);
                 }
@@ -148,10 +148,8 @@ namespace org {
                     }
 
                     numMarkers--;
-                    if (numMarkers == 0 && p > 0) { // release buffer when we can, but don't do unnecessary work
-                        // Copy data[p]..data[n-1] to data[0]..data[(n-1)-p], reset ptrs
-                        // p is last valid char; move nothing if p==n as we have no valid char
-                        System::arraycopy(data, p, data, 0, n - p); // shift n-p char from p to 0
+                    if (numMarkers == 0 && p > 0) {
+                        data.erase(0, p);
                         n = n - p;
                         p = 0;
                         lastCharBufferStart = lastChar;

--- a/org/antlr/v4/runtime/UnbufferedCharStream.h
+++ b/org/antlr/v4/runtime/UnbufferedCharStream.h
@@ -48,15 +48,13 @@ namespace org {
                 ///  that it doesn't buffer all data, not that's it's on demand loading of char.
                 /// </summary>
                 class UnbufferedCharStream : public CharStream {
+                  protected:
                     /// <summary>
                     /// A moving window buffer of the data being scanned. While there's a marker,
                     /// we keep adding to buffer. Otherwise, <seealso cref="#consume consume()"/> resets so
                     /// we start filling at index 0 again.
                     /// </summary>
-                   protected:
-//JAVA TO C++ CONVERTER WARNING: Since the array size is not known in this declaration, Java to C++ Converter has converted this array to a pointer.  You will need to call 'delete[]' where appropriate:
-//ORIGINAL LINE: protected char[] data;
-                       wchar_t *data;
+                    std::wstring data;
 
                     /// <summary>
                     /// The number of characters currently in <seealso cref="#data data"/>.


### PR DESCRIPTION
wstring_t seems a lot more convenient than wchar_t[] or *wchar_t
because it has all of the standard resizing capabilities of vector but
can be easily output if needed.