### PR TITLE
Integer precision fix for BitSet.

### DIFF
--- a/antlrcpp/BitSet.h
+++ b/antlrcpp/BitSet.h
@@ -68,7 +68,7 @@ public:
 	friend std::wostream& operator<<(std::wostream& os, const BitSet& obj)
 	{
 		os << L"{";
-		int total = obj.data.count();
+		size_t total = obj.data.count();
 		for (int i = 0; i < obj.data.size(); i++){
 			if (obj.data.test(i)){
 				os << i;


### PR DESCRIPTION
We could just use unsigned long here, but given that we’re limited to
max(size_t) bits using the same restriction for the count seems
reasonable.